### PR TITLE
Set hour to 0 in `firstofmonth`

### DIFF
--- a/webscraper/googlecalendar.py
+++ b/webscraper/googlecalendar.py
@@ -70,7 +70,7 @@ class Calendar:
         self.service = discovery.build('calendar', 'v3', http=http)
 
         # Get the event bounds.
-        firstofmonth = datetime.datetime.today().replace(day=1).isoformat() + 'Z'  # 'Z' indicates UTC time
+        firstofmonth = datetime.datetime.today().replace(day=1).replace(hour=0).isoformat() + 'Z'  # 'Z' indicates UTC time
         lastofmonth = datetime.datetime.today().replace(month=datetime.datetime.now().month + 1, day=1).isoformat() + \
                       'Z'  # 'Z' indicates UTC time
 


### PR DESCRIPTION
I noticed that the `firstofmonth` datetime doesn't set the hour to 0 which will result in it setting the hour to the current hour.
In cases where there is a shift on the first day of the month, it will not fetch the shift if the startTime is before the current hour

**Added**:
- `.replace(hour=0)` to `datetime.today()` [731492c
](https://github.com/StefanPahlplatz/albert-heijn-calendar-sync/commit/731492cda99b949328a541b17c3ce2d11713d69d) 