### PR TITLE
Increased maxResults to default value

### DIFF
--- a/webscraper/googlecalendar.py
+++ b/webscraper/googlecalendar.py
@@ -76,7 +76,7 @@ class Calendar:
 
         # Get this months events.
         events_result = self.service.events().list(
-            calendarId='primary', timeMin=firstofmonth, timeMax=lastofmonth, maxResults=20, singleEvents=True,
+            calendarId='primary', timeMin=firstofmonth, timeMax=lastofmonth, maxResults=250, singleEvents=True,
             orderBy='startTime').execute()
 
         # Save the events to check for duplicates later.


### PR DESCRIPTION
I think having the maxResults set to `20` is rather low, considering it will not only retrieve the shifts per month, but also other events in the calendar. Increasing it to the default value (`250`) of the `Google Calendar API` would be better in my opinion

This is of course easily changed locally, but having it set to `250` in the repo would be great

**Changed**:
- `maxResults` to `250` [86023bf](https://github.com/StefanPahlplatz/albert-heijn-calendar-sync/commit/86023bf70599ca62c2c981f1716aeeda0558cfc2) 
